### PR TITLE
Add templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,15 @@ The rest of parameters are `meta-variable patterns` also known as `key = value` 
 these are processed as replaces, *or format if the call is all-static*. When a template (`{}`) is found with
 the name of a key inside it gets replaced for whatever is the `Display` implementation of the value. This meaning
 that the value must always implement `Display`. Otherwise, if you want to have a `{}` inside your translation,
-you can escape it the same way `format!` does, by using `{{}}`.
+you can escape it the same way `format!` does, by using `{{}}`. Just like object construction works in rust, if
+you have a parameter like `x = x`, you can shorten it to `x`.
 
 Depending on whether the parameters are static or dynamic the macro will act different, differing whether
 the checks are compile-time or run-time, the following table is a macro behavior matrix.
 
 | Parameters                                         | Compile-Time checks                                      | Return type                                                                       |
 |----------------------------------------------------|----------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `static language` + `static path` (most optimized) | Path existence, Language validity, \*Template validation | `&'static str` (stack) if there are no templates or `String` (heap) if there are. |
+| `static language` + `static path` (most optimized) | Path existence, Language validity                        | `&'static str` (stack) if there are no templates or `String` (heap) if there are. |
 | `dynamic language` + `dynamic path`                | None                                                     | `Result<String, TranslatableError>` (heap)                                        |
 | `static language` + `dynamic path`                 | Language validity                                        | `Result<String, TranslatableError>` (heap)                                        |
 | `dynamic language` + `static path` (commonly used) | Path existence                                           | `Result<String, TranslatableError>` (heap)                                        |
@@ -99,12 +100,6 @@ dynamic parameters than there are with static parameters.
 
 - The runtime errors implement a `cause()` method that returns a heap allocated `String` with the error reason, essentially
 the error display.
-
-- Template validation in static parameter handling means purely variable existence, an all-static invocation
-generates a quoted translation (`""`), essentially the same value you can find in your translation file, so if the
-invocation is all-static the macro will generate a `format!` call, which implicitly validates the variable
-existence, if the variable is found outer scope the macro may use that. In the case where any of the
-parameters is dynamic, the macro will return an error if some replacement couldn't be found.
 
 ## Example implementation 📂
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 A robust internationalization solution for Rust featuring compile-time validation, ISO 639-1 compliance, and TOML-based translation management.
 
+**This library prioritizes ergonomics over raw performance.**
+Our goal is not to be *blazingly fast* but to provide the most user-friendly experience for implementing translations—whether you're a first-time user or an experienced developer. If you require maximum performance, consider alternative libraries, a custom implementation, or even hard-coded values on the stack.
+
 ## Table of Contents 📖
 
 - [Features](#features-)
@@ -63,7 +66,7 @@ The translation files have three rules
 The load configuration such as `seek_mode` and `overlap` is not relevant here, as previously
 specified, these configuration values only get applied once by reversing the translations conveniently.
 
-To load translations you make use of the `translatable::translation` macro, that macro requires two
+To load translations you make use of the `translatable::translation` macro, that macro requires at least two
 parameters to be passed.
 
 The first parameter consists of the language which can be passed dynamically as a variable or an expression
@@ -74,6 +77,12 @@ The second parameter consists of the path, which can be passed dynamically as a 
 that resolves to an `impl Into<String>` with the format `path.to.translation`, or statically with the following
 syntax `static path::to::translation`.
 
+The rest of parameters are `meta-variable patterns` also known as `key = value` parameters or key-value pairs,
+these are processed as replaces, *or format if the call is all-static*. When a template (`{}`) is found with
+the name of a key inside it gets replaced for whatever is the `Display` implementation of the value. This meaning
+that the value must always implement `Display`. Otherwise, if you want to have a `{}` inside your translation,
+you can escape it the same way `format!` does, by using `{{}}`.
+
 Depending on whether the parameters are static or dynamic the macro will act different, differing whether
 the checks are compile-time or run-time, the following table is a macro behavior matrix.
 
@@ -82,7 +91,7 @@ the checks are compile-time or run-time, the following table is a macro behavior
 | `static language` + `static path` (most optimized) | Path existence, Language validity, \*Template validation | `&'static str` (stack) if there are no templates or `String` (heap) if there are. |
 | `dynamic language` + `dynamic path`                | None                                                     | `Result<String, TranslatableError>` (heap)                                        |
 | `static language` + `dynamic path`                 | Language validity                                        | `Result<String, TranslatableError>` (heap)                                        |
-| `dynamic language` + `static path` (commonly used) | Path existence, \*Template validation                    | `Result<String, TranslatableError>` (heap)                                        |
+| `dynamic language` + `static path` (commonly used) | Path existence                                           | `Result<String, TranslatableError>` (heap)                                        |
 
 - For the error handling, if you want to integrate this with `thiserror` you can use a `#[from] translatable::TranslationError`,
 as a nested error, all the errors implement display, for optimization purposes there are not the same amount of errors with
@@ -91,10 +100,11 @@ dynamic parameters than there are with static parameters.
 - The runtime errors implement a `cause()` method that returns a heap allocated `String` with the error reason, essentially
 the error display.
 
-- Template validation in the static parameter handling means variable existence, since templates are generated as a `format!`
-call which processes expressions found in scope. It's always recommended to use full paths in translation templates
-to avoid needing to make variables in scope, unless the calls are contextual, in that case there is nothing that can
-be done to avoid making variables.
+- Template validation in static parameter handling means purely variable existence, an all-static invocation
+generates a quoted translation (`""`), essentially the same value you can find in your translation file, so if the
+invocation is all-static the macro will generate a `format!` call, which implicitly validates the variable
+existence, if the variable is found outer scope the macro may use that. In the case where any of the
+parameters is dynamic, the macro will return an error if some replacement couldn't be found.
 
 ## Example implementation 📂
 
@@ -129,22 +139,21 @@ es = "¡Hola {name}!"
 
 ### Example application usage
 
-Notice how that template is in scope, whole expressions can be used
-in the templates such as `path::to::function()`, or other constants.
+Notice how there is a template, this template is being replaced by the
+`name = "john"` key value pair passed as third parameter.
 
 ```rust
 extern crate translatable;
 use translatable::translation;
 
 fn main() {
-	let dynamic_lang = "es";
-	let dynamic_path = "common.greeting"
-	let name = "john";
+    let dynamic_lang = "es";
+    let dynamic_path = "common.greeting"
 
-	assert!(translation!("es", static common::greeting) == "¡Hola john!");
-	assert!(translation!("es", dynamic_path).unwrap() == "¡Hola john!".into());
-	assert!(translation!(dynamic_lang, static common::greeting).unwrap() == "¡Hola john!".into());
-	assert!(translation!(dynamic_lang, dynamic_path).unwrap() == "¡Hola john!".into());
+    assert!(translation!("es", static common::greeting) == "¡Hola john!", name = "john");
+    assert!(translation!("es", dynamic_path).unwrap() == "¡Hola john!".into(), name = "john");
+    assert!(translation!(dynamic_lang, static common::greeting).unwrap() == "¡Hola john!".into(), name = "john");
+    assert!(translation!(dynamic_lang, dynamic_path).unwrap() == "¡Hola john!".into(), name = "john");
 }
 ```
 

--- a/translatable/tests/test.rs
+++ b/translatable/tests/test.rs
@@ -17,7 +17,8 @@ fn language_static_path_dynamic() {
 #[test]
 fn language_dynamic_path_static() {
     let language = "es";
-    let result = translation!(language, static common::greeting, name = "john");
+    let name = "john";
+    let result = translation!(language, static common::greeting, name = name);
 
     assert!(result.unwrap() == "¡Hola john!".to_string())
 }

--- a/translatable/tests/test.rs
+++ b/translatable/tests/test.rs
@@ -29,7 +29,7 @@ fn language_dynamic_path_static() {
 fn both_dynamic() {
     let name = "john";
     let language = "es";
-    let result = translation!(language, "common.greeting");
+    let result = translation!(language, "common.greeting", lol = 10, name);
 
     assert!(result.unwrap() == "¡Hola john!".to_string())
 }

--- a/translatable/tests/test.rs
+++ b/translatable/tests/test.rs
@@ -2,34 +2,30 @@ use translatable::translation;
 
 #[test]
 fn both_static() {
-    let name = "john";
-    let result = translation!("es", static common::greeting);
+    let result = translation!("es", static common::greeting, name = "john");
 
     assert!(result == "¡Hola john!")
 }
 
 #[test]
 fn language_static_path_dynamic() {
-    let name = "john";
-    let result = translation!("es", "common.greeting");
+    let result = translation!("es", "common.greeting", name = "john");
 
     assert!(result.unwrap() == "¡Hola john!".to_string())
 }
 
 #[test]
 fn language_dynamic_path_static() {
-    let name = "john";
     let language = "es";
-    let result = translation!(language, static common::greeting);
+    let result = translation!(language, static common::greeting, name = "john");
 
     assert!(result.unwrap() == "¡Hola john!".to_string())
 }
 
 #[test]
 fn both_dynamic() {
-    let name = "john";
     let language = "es";
-    let result = translation!(language, "common.greeting", lol = 10, name);
+    let result = translation!(language, "common.greeting", lol = 10, name = "john");
 
     assert!(result.unwrap() == "¡Hola john!".to_string())
 }

--- a/translatable_proc/src/macros.rs
+++ b/translatable_proc/src/macros.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Display;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
@@ -211,7 +212,7 @@ pub fn translation_macro(args: TranslationArgs) -> TokenStream {
 }
 
 /// Helper function to create compile error tokens
-fn error_token(e: &impl std::fmt::Display) -> TokenStream {
+fn error_token(e: &impl Display) -> TokenStream {
     let msg = format!("{e:#}");
     quote! { compile_error!(#msg) }
 }

--- a/translatable_proc/src/translations/generation.rs
+++ b/translatable_proc/src/translations/generation.rs
@@ -14,10 +14,20 @@ fn kwarg_dynamic_replaces(format_kwargs: HashMap<String, TokenStream>) -> Vec<To
         .iter()
         .map(|(key, value)|
             quote! {
-                .map(|translation| translation.replace(
-                    format!("{{{}}}", #key).as_str(),
-                    format!("{:#}", #value).as_str()
-                ))
+                .map(|translation| translation
+                    .replace(
+                        format!("{{{{{}}}}}", #key).as_str(), // Replace {{key}} -> a temporary placeholder
+                        format!("\x01{{{}}}\x01", #key).as_str()
+                    )
+                    .replace(
+                        format!("{{{}}}", #key).as_str(), // Replace {key} -> value
+                        format!("{:#}", #value).as_str()
+                    )
+                    .replace(
+                        format!("\x01{{{}}}\x01", #key).as_str(), // Restore {key} from the placeholder
+                        format!("{{{}}}", #key).as_str()
+                    )
+                )
             }
         )
         .collect::<Vec<_>>()

--- a/translatable_proc/src/translations/generation.rs
+++ b/translatable_proc/src/translations/generation.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use strum::IntoEnumIterator;
@@ -65,6 +67,7 @@ pub fn load_lang_dynamic(lang: TokenStream) -> Result<TokenStream, TranslationEr
 pub fn load_translation_static(
     static_lang: Option<Iso639a>,
     path: String,
+    format_kwargs: HashMap<String, TokenStream>
 ) -> Result<TokenStream, TranslationError> {
     let translation_object = load_translations()?
         .iter()
@@ -114,6 +117,7 @@ pub fn load_translation_static(
 pub fn load_translation_dynamic(
     static_lang: Option<Iso639a>,
     path: TokenStream,
+    format_kwargs: HashMap<String, TokenStream>
 ) -> Result<TokenStream, TranslationError> {
     let nestings = load_translations()?
         .iter()


### PR DESCRIPTION
This PR closes #6, this adds translation templates by leveraging `.replace()` in all cases. This would leave the only case where a translation is not heap allocated when the translation does not contain templates and the macro invocation is `all-static`.

The only missing thing is generating a warning when `x = x` is used instead of `x`, but for that we need [`compile_warning!`](https://github.com/rust-lang/rust/pull/135432). Which isn't going to be released probably until 2026.

I'd say we can leave that commented, document and merge. Then implement it when it's implemented into the standard library.

The README is updated with the modifications this PR makes, there is no actual checking for macros as it would possibly need to change how the macro works entirely, and I believe that's also unnecessary. Escaping still works for the edge case where you have an actual parameter and you want to do something like `{{x}} = {x}` inside the translation for some reason.