### PR TITLE
Repository metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report unexpected behavior or crashes
 title: "[BUG] "
-labels: ["bug", "triage"]
+labels: ["bug-report", "triage"]
 body:
   - type: checkboxes
     attributes:
@@ -11,6 +11,8 @@ body:
           required: true
         - label: I've read the [Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct)
           required: true
+        - label: Are you using the latest translatable version?
+          required: true
 
   - type: dropdown
     attributes:
@@ -19,21 +21,13 @@ body:
         - Core library
         - Macros crate
         - Documentation
-        - CI/CD
-    validations:
-      required: true
-
-  - type: input
-    attributes:
-      label: Translatable Version
-      placeholder: 0.x.x
     validations:
       required: true
 
   - type: input
     attributes:
       label: Rust Version
-      placeholder: Output of `rustc -V`
+      placeholder: Output of `rustc --version`
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,55 @@
+name: Bug Report
+description: Report unexpected behavior or crashes
+title: "[BUG] "
+labels: ["bug", "triage"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I've checked existing issues and pull requests
+          required: true
+        - label: I've read the [Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct)
+          required: true
+
+  - type: dropdown
+    attributes:
+      label: Component
+      options:
+        - Core library
+        - Macros crate
+        - Documentation
+        - CI/CD
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Translatable Version
+      placeholder: 0.x.x
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Rust Version
+      placeholder: Output of `rustc -V`
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Steps
+      description: Step-by-step instructions to reproduce the issue
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected vs Actual Behavior
+      description: What you expected to happen vs what actually happened
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Logs, screenshots, or code samples

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea for Translatable
 title: "[FEATURE] "
-labels: ["enhancement", "triage"]
+labels: ["feature-request", "triage"]
 body:
   - type: checkboxes
     attributes:
@@ -23,6 +23,8 @@ body:
     attributes:
       label: Proposed Solution
       description: How should Translatable address this problem?
+    validations:
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Suggest an idea for Translatable
+title: "[FEATURE] "
+labels: ["enhancement", "triage"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I've checked existing issues and pull requests
+          required: true
+        - label: I've read the [Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Problem Description
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed Solution
+      description: How should Translatable address this problem?
+
+  - type: textarea
+    attributes:
+      label: Alternatives Considered
+      description: Other ways this could potentially be solved
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Potential disadvantages, edge cases, or examples

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,28 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: "💬 Community Help (Discord)"
+    url: https://discord.gg/AJWFyps23a
+    about: |
+      For general questions, discussion, or brainstorming:
+      - Get real-time help from maintainers
+      - Discuss potential features
+      - Chat with other contributors
+      *Please check existing issues first!*
+
+  - name: "⚖️ Code of Conduct"
+    url: https://www.rust-lang.org/policies/code-of-conduct
+    about: |
+      All community interactions must follow:
+      - Rust's Code of Conduct
+      - Project-specific guidelines
+      *Required reading before participating*
+
+  - name: "🚨 Moderation Contact"
+    url: mailto:esteve@memw.es
+    about: |
+      For urgent moderation issues:
+      - Code of Conduct violations
+      - Community safety concerns
+      - Escalation requests
+      *Do NOT contact Rust moderation team*

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,3 @@
+# Useful resources
+
+- [Discord server](https://discord.gg/AJWFyps23a)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at `esteve@memw.es` or `chiko@envs.net`. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# Translatable Code of Conduct
 
 ## Our Pledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to translatable
+
+In translatable we welcome any contribution from anyone, bug reports, pull requests, and feedback.
+This document serves as guidance if you are thinking of submitting any of the above.
+
+## Submitting bug reports and feature requests
+
+To submit a bug report or feature request you can open an issue in this repository `FlakySL/translatable`.
+
+When reporting a bug or asking for help, please include enough details so that the people helping you
+can reproduce the behavior you are seeking. For some tips on how to approach this, read about how to
+produce a (Minimal, Complete, and Verifiable example)[https://stackoverflow.com/help/minimal-reproducible-example].
+
+When making a feature request, please make it clear what problem you intend to solve with the feature,
+any ideas for how translatable could support solving that problem, any possible alternatives, and any
+disadvantages.
+
+Before submitting anything please, check that another issue with your same problem/request does not
+already exist, if you want to extend on a problem or have an actual conversation about it, you can
+use our discord channel [at Flaky](https://discord.gg/AJWFyps23a).
+
+It is recommended that you use the issue templates provided in this repository.
+
+## Running tests and compiling the project
+
+This project uses [`make`](https://www.gnu.org/software/make/) for everything you may want to run.
+
+- To run tests you can use the `make test` command, that runs both integration and unit tests.
+- To compile the project alone you may use `make compile`, that simply compiles the project in each
+target directory.
+
+## Code of conduct
+
+In translatable and community we abide by the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct).
+For escalation or moderation issues please contact Esteve ([esteve@memw.es](esteve@memw.es)) instead of the Rust moderation team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,30 @@
-# Contributing to translatable
+# Contributing to Translatable
 
-In translatable we welcome any contribution from anyone, bug reports, pull requests, and feedback.
-This document serves as guidance if you are thinking of submitting any of the above.
+In Translatable, we welcome contributions from everyone, including bug reports, pull requests, and feedback. This document serves as guidance if you are considering submitting any of the above.
 
-## Submitting bug reports and feature requests
+## Submitting Bug Reports and Feature Requests
 
-To submit a bug report or feature request you can open an issue in this repository `FlakySL/translatable`.
+To submit a bug report or feature request, you can open an issue in this repository: [`FlakySL/translatable.rs`](https://github.com/FlakySL/translatable.rs).
 
-When reporting a bug or asking for help, please include enough details so that the people helping you
-can reproduce the behavior you are seeking. For some tips on how to approach this, read about how to
-produce a (Minimal, Complete, and Verifiable example)[https://stackoverflow.com/help/minimal-reproducible-example].
+When reporting a bug or requesting help, please include sufficient details to allow others to reproduce the behavior you're encountering. For guidance on how to approach this, read about [How to Create a Minimal, Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example).
 
-When making a feature request, please make it clear what problem you intend to solve with the feature,
-any ideas for how translatable could support solving that problem, any possible alternatives, and any
-disadvantages.
+When making a feature request, please clearly explain:
+1. The problem you want to solve
+2. How Translatable could help address this problem
+3. Any potential alternatives
+4. Possible disadvantages of your proposal
 
-Before submitting anything please, check that another issue with your same problem/request does not
-already exist, if you want to extend on a problem or have an actual conversation about it, you can
-use our discord channel [at Flaky](https://discord.gg/AJWFyps23a).
+Before submitting, please verify that no existing issue addresses your specific problem/request. If you want to elaborate on a problem or discuss it further, you can use our [Discord channel](https://discord.gg/AJWFyps23a) at Flaky.
 
-It is recommended that you use the issue templates provided in this repository.
+We recommend using the issue templates provided in this repository.
 
-## Running tests and compiling the project
+## Running Tests and Compiling the Project
 
-This project uses [`make`](https://www.gnu.org/software/make/) for everything you may want to run.
+This project uses [`make`](https://www.gnu.org/software/make/) for all common tasks:
 
-- To run tests you can use the `make test` command, that runs both integration and unit tests.
-- To compile the project alone you may use `make compile`, that simply compiles the project in each
-target directory.
+- Run `make test` to execute both integration and unit tests
+- Use `make compile` to compile the project in each target directory
 
-## Code of conduct
+## Code of Conduct
 
-In translatable and community we abide by the [Rust code of conduct](https://www.rust-lang.org/policies/code-of-conduct).
-For escalation or moderation issues please contact Esteve ([esteve@memw.es](esteve@memw.es)) instead of the Rust moderation team.
+The Translatable community follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct). For moderation issues or escalation, please contact Esteve at [esteve@memw.es](mailto:esteve@memw.es) rather than the Rust moderation team.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = [ "translatable", "translatable_proc" ]
+members = ["translatable", "translatable_proc"]

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,8 +3,8 @@
 
 This project is mainly maintained by the authors listed in both `translatable/Cargo.toml` and `translatable_proc/Cargo.toml`.
 
-- Esteve Autet <esteve@memw.es>
-- Chiko <chiko@envs.net>
+- Esteve Autet `esteve@memw.es`
+- Chiko `chiko@envs.net`
 
 There is no hierarchy established (yet) but this might be subject to change soon. For any inquiries you can
 contact any of the emails listed above.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,10 @@
+
+# Governance and moderation
+
+This project is mainly maintained by the authors listed in both `translatable/Cargo.toml` and `translatable_proc/Cargo.toml`.
+
+- Esteve Autet <esteve@memw.es>
+- Chiko <chiko@envs.net>
+
+There is no hierarchy established (yet) but this might be subject to change soon. For any inquiries you can
+contact any of the emails listed above.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,5 @@
 
-# Governance and moderation
+# Governance and Moderation
 
 This project is mainly maintained by the authors listed in both `translatable/Cargo.toml` and `translatable_proc/Cargo.toml`.
 

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README-MACROS.md
+++ b/README-MACROS.md
@@ -1,0 +1,10 @@
+# Translatable macros
+
+The sole purpose of this crate is exporting macros for the [translatable](https://crates.io/crates/translatable)
+package, using this crate without the other one is not supported, and support requests or bug reports
+for the use of this will redirect you to use [translatable](https://crates.io/crates/translatable).
+
+## Licensing
+
+Licensing for this crate follows the [translatable](https://crates.io/crates/translatable) licensing,
+as they are essentially the same package.

--- a/README-MACROS.md
+++ b/README-MACROS.md
@@ -1,10 +1,7 @@
-# Translatable macros
+# Translatable Macros
 
-The sole purpose of this crate is exporting macros for the [translatable](https://crates.io/crates/translatable)
-package, using this crate without the other one is not supported, and support requests or bug reports
-for the use of this will redirect you to use [translatable](https://crates.io/crates/translatable).
+This crate exists solely to provide macros for the [Translatable](https://crates.io/crates/translatable) crate. Using this crate without the main Translatable crate is **not supported**, and any support requests or bug reports regarding standalone usage will be redirected to the [Translatable](https://crates.io/crates/translatable) crate.
 
 ## Licensing
 
-Licensing for this crate follows the [translatable](https://crates.io/crates/translatable) licensing,
-as they are essentially the same package.
+This crate shares the same licensing terms as [Translatable](https://crates.io/crates/translatable), as these crates are essentially part of the same ecosystem.

--- a/README.md
+++ b/README.md
@@ -148,3 +148,13 @@ fn main() {
 }
 ```
 
+## License
+
+<sup>
+This repository is licensed under either of <a href="LICENSE-APACHE">Apache License, Version 2.0</a>
+or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+Unless you explicitly state any contribution intentionally submitted
+for inclusion in translatable by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A robust internationalization solution for Rust featuring compile-time validatio
 - [Installation](#installation-)
 - [Usage](#usage-)
 - [Example implementation](#example-implementation-)
+- [Licensing](#license-)
 
 ## Features 🚀
 
@@ -148,7 +149,7 @@ fn main() {
 }
 ```
 
-## License
+## License 📜
 
 <sup>
 This repository is licensed under either of <a href="LICENSE-APACHE">Apache License, Version 2.0</a>

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ This repository is licensed under either of <a href="LICENSE-APACHE">Apache Lice
 or <a href="LICENSE-MIT">MIT license</a> at your option.
 </sup>
 
+<sub>
 Unless you explicitly state any contribution intentionally submitted
 for inclusion in translatable by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+</sub>

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ fn main() {
 This repository is licensed under either of <a href="LICENSE-APACHE">Apache License, Version 2.0</a>
 or <a href="LICENSE-MIT">MIT license</a> at your option.
 </sup>
-
+<br>
 <sub>
 Unless you explicitly state any contribution intentionally submitted
 for inclusion in translatable by you, as defined in the Apache-2.0 license, shall be

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+
+# Security Vulnerabilities
+
+This library does not directly interact with networking, or anything another person
+might be able to do to access the service using this library.
+
+To update the dependencies and solve vulnerability issues within we use dependabot,
+which we believe a safe enough alternative to update all the dependencies
+in the project.

--- a/translatable/Cargo.toml
+++ b/translatable/Cargo.toml
@@ -7,7 +7,13 @@ readme = "../README.md"
 version = "0.1.0"
 edition = "2024"
 authors = ["Esteve Autet <esteve@memw.es>", "Chiko <chiko@envs.net>"]
-tags = ["i18n", "translations", "idioms", "languages", "internazionalization"]
+keywords = [
+    "i18n",
+    "translations",
+    "idioms",
+    "languages",
+    "internazionalization",
+]
 
 [dependencies]
 thiserror = "2.0.12"

--- a/translatable/Cargo.toml
+++ b/translatable/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "translatable"
+description = "A robust internationalization solution for Rust featuring compile-time validation, ISO 639-1 compliance, and TOML-based translation management. "
+repository = "https://github.com/FlakySL/translatable.rs"
+license = "MIT OR Apache-2.0"
+readme = "../README.md"
 version = "0.1.0"
 edition = "2024"
+authors = ["Esteve Autet <esteve@memw.es>", "chikof"]
+tags = ["i18n", "translations", "idioms", "languages", "internazionalization"]
 
 [dependencies]
 thiserror = "2.0.12"

--- a/translatable/Cargo.toml
+++ b/translatable/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 version = "0.1.0"
 edition = "2024"
-authors = ["Esteve Autet <esteve@memw.es>", "chikof"]
+authors = ["Esteve Autet <esteve@memw.es>", "Chiko <chiko@envs.net>"]
 tags = ["i18n", "translations", "idioms", "languages", "internazionalization"]
 
 [dependencies]

--- a/translatable_proc/Cargo.toml
+++ b/translatable_proc/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "../README-MACROS.md"
 version = "0.1.0"
 edition = "2024"
-authors = ["Esteve Autet <esteve@memw.es>", "chikof"]
+authors = ["Esteve Autet <esteve@memw.es>", "Chiko <chiko@envs.net>"]
 
 [lib]
 proc-macro = true

--- a/translatable_proc/Cargo.toml
+++ b/translatable_proc/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "translatable_proc"
+description = "Proc macro crate for the translatable library."
+repository = "https://github.com/FlakySL/translatable.rs"
+license = "MIT OR Apache-2.0"
+readme = "../README-MACROS.md"
 version = "0.1.0"
 edition = "2024"
+authors = ["Esteve Autet <esteve@memw.es>", "chikof"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This PR closes #8, adds licensing, authoring, documents make which is not implemented yet, but should possibly be implemented in this PR and adds a `CONTRIBUTING.md` file.

The other things such as repository templates and so on are repository configuration, so that's outside of this PR's scope.